### PR TITLE
Use weights_only for load

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -219,7 +219,7 @@ def _load_model(checkpoint_path, device, precision, use_tp):
         simple_quantizer = WeightOnlyInt4QuantHandler(model, groupsize)
         model = simple_quantizer.convert_for_runtime()
 
-    checkpoint = torch.load(str(checkpoint_path), mmap=True)
+    checkpoint = torch.load(str(checkpoint_path), mmap=True, weights_only=True)
     model.load_state_dict(checkpoint, assign=True)
 
     if use_tp:

--- a/quantize.py
+++ b/quantize.py
@@ -540,7 +540,7 @@ def quantize(
     with torch.device('meta'):
         model = Transformer.from_name(checkpoint_path.parent.name)
 
-    checkpoint = torch.load(str(checkpoint_path), mmap=True)
+    checkpoint = torch.load(str(checkpoint_path), mmap=True, weights_only=True)
     model.load_state_dict(checkpoint, assign=True)
     model = model.to(dtype=precision, device=device)
 

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -64,7 +64,7 @@ def convert_hf_checkpoint(
 
     merged_result = {}
     for file in sorted(bin_files):
-        state_dict = torch.load(str(file), map_location="cpu", mmap=True)
+        state_dict = torch.load(str(file), map_location="cpu", mmap=True, weights_only=True)
         merged_result.update(state_dict)
     final_result = {}
     for key, value in merged_result.items():


### PR DESCRIPTION
`torch.load` without `weights_only` is unsafe.
We probably want to set it to follow best practices as this code will likely be reused.

If `weights_only=True` doesn't work here, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/