### PR TITLE
Sort imports.

### DIFF
--- a/GPTQ.py
+++ b/GPTQ.py
@@ -3,14 +3,16 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
+import os
+import sys
+
 import torch
-import os, sys
+
 lm_evaluation_harness_path = "/".join(
     os.getcwd().split("/")[:-1] + ["lm-evaluation-harness"]
 )
 sys.path.insert(0, lm_evaluation_harness_path)
 import main as lm_evaluation_harness_main
-
 import torch.fx as fx
 import torch.nn as nn
 import torch.nn.functional as F

--- a/eval.py
+++ b/eval.py
@@ -9,9 +9,9 @@ from pathlib import Path
 from typing import Optional
 
 import torch
-
-import torch._inductor.config
 import torch._dynamo.config
+import torch._inductor.config
+
 torch._dynamo.config.automatic_dynamic_shapes = True
 torch._inductor.config.triton.unique_kernel_names = True
 torch._inductor.config.epilogue_fusion = False
@@ -22,23 +22,21 @@ torch._dynamo.config.cache_size_limit = 100000
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from model import LLaMA
-from sentencepiece import SentencePieceProcessor
-
 # hacky path setup for lm-evaluation-harness
 import os
 import sys
+
+from sentencepiece import SentencePieceProcessor
+
+from model import LLaMA
+
 lm_evaluation_harness_path = '/'.join(
     os.getcwd().split('/')[:-1] + ['lm-evaluation-harness'])
 sys.path.insert(0, lm_evaluation_harness_path)
-import main as lm_evaluation_harness_main
 import lm_eval
+import main as lm_evaluation_harness_main
 
-from generate import (
-    _load_model,
-    encode_tokens,
-    model_forward,
-)
+from generate import _load_model, encode_tokens, model_forward
 
 
 def setup_cache_padded_seq_input_pos_max_seq_length_for_prefill(

--- a/generate.py
+++ b/generate.py
@@ -3,15 +3,16 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
+import itertools
 import sys
 import time
 from pathlib import Path
 from typing import Optional, Tuple
-import itertools
-import torch
 
-import torch._inductor.config
+import torch
 import torch._dynamo.config
+import torch._inductor.config
+
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
 torch._inductor.config.fx_graph_cache = True # Experimental feature to reduce compilation times, will be on by default in future
@@ -21,9 +22,11 @@ torch._inductor.config.fx_graph_cache = True # Experimental feature to reduce co
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
+from sentencepiece import SentencePieceProcessor
+
 from model import Transformer
 from tp import maybe_init_dist
-from sentencepiece import SentencePieceProcessor
+
 
 def multinomial_sample_one_no_sync(probs_sort): # Does multinomial sampling without a cuda synchronization
     q = torch.empty_like(probs_sort).exponential_(1)

--- a/model.py
+++ b/model.py
@@ -3,7 +3,6 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-import math
 from dataclasses import dataclass
 from typing import Optional
 

--- a/model.py
+++ b/model.py
@@ -8,8 +8,9 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
-from torch.nn import functional as F
 from torch import Tensor
+from torch.nn import functional as F
+
 
 def find_multiple(n: int, k: int) -> int:
     if n % k == 0:

--- a/quantize.py
+++ b/quantize.py
@@ -3,13 +3,10 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-import importlib
 import time
 from pathlib import Path
 
 import torch
-import importlib
-import time
 
 import torch.nn as nn
 import torch.nn.functional as F

--- a/quantize.py
+++ b/quantize.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 import importlib
 import time
-from math import ceil
 from pathlib import Path
 
 import torch

--- a/quantize.py
+++ b/quantize.py
@@ -7,11 +7,8 @@ import time
 from pathlib import Path
 
 import torch
-
 import torch.nn as nn
 import torch.nn.functional as F
-
-from pathlib import Path
 from sentencepiece import SentencePieceProcessor
 
 try:

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -4,18 +4,19 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Optional
 
 import torch
-import re
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from model import ModelArgs
+
 
 @torch.inference_mode()
 def convert_hf_checkpoint(

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -4,8 +4,10 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 import os
-from requests.exceptions import HTTPError
 from typing import Optional
+
+from requests.exceptions import HTTPError
+
 
 def hf_download(repo_id: Optional[str] = None, hf_token: Optional[str] = None) -> None:
     from huggingface_hub import snapshot_download

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -5,8 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 import os
 from requests.exceptions import HTTPError
-import sys
-from pathlib import Path
 from typing import Optional
 
 def hf_download(repo_id: Optional[str] = None, hf_token: Optional[str] = None) -> None:

--- a/tp.py
+++ b/tp.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 import os
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
-from torch import nn
 import torch.distributed as dist
+from torch import nn
 from torch.distributed import _functional_collectives as funcol
-from model import Transformer, Attention, FeedForward
+
+from model import Attention, FeedForward, Transformer
 from quantize import WeightOnlyInt4Linear
 
 

--- a/tp.py
+++ b/tp.py
@@ -11,7 +11,7 @@ from torch import nn
 import torch.distributed as dist
 from torch.distributed import _functional_collectives as funcol
 from model import Transformer, Attention, FeedForward
-from quantize import WeightOnlyInt4Linear, WeightOnlyInt8Linear
+from quantize import WeightOnlyInt4Linear
 
 
 def _get_rank() -> int:


### PR DESCRIPTION
Removed redundancy by removing duplicates and unused imports.
Also run `isort` to organise the imports.