### PR TITLE
Speed up model loading by 25%

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -323,8 +323,9 @@ def main(
                 nonlocal done_generating
                 if done_generating:
                     return
-                buffer.append(tokenizer.decode([period_id] + x.tolist())[1:])
-                if x.item() == tokenizer.eos_id():
+                x = x.item()
+                buffer.append(tokenizer.decode([period_id, x])[1:])
+                if x == tokenizer.eos_id():
                     done_generating = True
                 if len(buffer) == 4 or done_generating:
                     print(''.join(buffer), end='', flush=True)

--- a/generate.py
+++ b/generate.py
@@ -219,8 +219,10 @@ def _load_model(checkpoint_path, device, precision, use_tp):
         simple_quantizer = WeightOnlyInt4QuantHandler(model, groupsize)
         model = simple_quantizer.convert_for_runtime()
 
-    checkpoint = torch.load(str(checkpoint_path), mmap=True, weights_only=True)
-    model.load_state_dict(checkpoint, assign=True)
+    # if TP>1 the model is likely too big to fit into single device,
+    # and we are more likely to run out GPU memory before RAM.
+    checkpoint = torch.load(str(checkpoint_path), map_location=None if use_tp else device, mmap=True, weights_only=True)
+    model.load_state_dict(checkpoint, strict=True, assign=True)
 
     if use_tp:
         from tp import apply_tp

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -78,6 +78,7 @@ def convert_hf_checkpoint(
         else:
             new_key = weight_map[key]
 
+        value = value.to(dtype=torch.bfloat16)
         final_result[new_key] = value
 
     for key in tuple(final_result.keys()):


### PR DESCRIPTION
Load checkpoint directly to device, in my testing loading llama 7B went from 7.83 to 5.78 seconds (about 25% faster). I also noticed that memory usage doubles temporarily, at least until compilation finishes. My understanding is that it's due to storing the checkpoint in `float16`, so at loading time when we `mmap` it and assign we still have to cast them to `bfloat16`, which probably results in more allocation. Hence the change to `convert_hf_checkpoint`to store weights in `bfloat16` which is what is used by in generate by default. After re-exporting `.pth` files I no longer observed temporary 2x spike in GPU memory. 

Also fix #22.