### PR TITLE
Support code gen for non-cuda targets with gpt-fast

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -24,7 +24,7 @@ def device_sync(device):
 
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
-# torch._inductor.config.fx_graph_cache = True # Experimental feature to reduce compilation times, will be on by default in future
+torch._inductor.config.fx_graph_cache = True # Experimental feature to reduce compilation times, will be on by default in future
 
 
 # support running without installing as a package

--- a/generate.py
+++ b/generate.py
@@ -314,9 +314,8 @@ def main(
     torch.manual_seed(1234)
     model_size = sum([p.numel() * p.dtype.itemsize for p in itertools.chain(model.parameters(), model.buffers())])
     if compile:
-        # MKG
-        # if is_speculative and use_tp:
-        #     torch._inductor.config.triton.cudagraph_trees = False # Bug with cudagraph trees in this case
+        if is_speculative and use_tp: # and ("cuda" in device):
+            torch._inductor.config.triton.cudagraph_trees = False # Bug with cudagraph trees in this case
 
         if is_speculative:
             global model_forward, logits_to_prob


### PR DESCRIPTION
Extend existing device variable to support code gen for other targets.

New args to generate
-- use_sdpa # by default, SDPA is disabled for best performance on CUDA. CPU presents different tradeoffs
--device ['cpu', 'cuda'] # we have the option to add devices such as MPS in the future

