### PR TITLE
Allow small modes to work with convert_hf_checkpoint. Added TinyLLama to the model list

### DIFF
--- a/model.py
+++ b/model.py
@@ -50,6 +50,7 @@ class ModelArgs:
 
 
 transformer_configs = {
+    "TinyLlama-1.1B-intermediate-step-480k-1T": dict(block_size=2048, vocab_size=32000, intermediate_size=5632, n_layer=22, n_head=32, n_local_heads=4, dim=2048),
     "CodeLlama-7b-Python-hf": dict(block_size=16384, vocab_size=32000, n_layer=32, dim = 4096, rope_base=1000000),
     "7B": dict(n_layer=32, n_head=32, dim=4096),
     "13B": dict(n_layer=40, n_head=40, dim=5120),


### PR DESCRIPTION
Small models in HF don't have pytorch_model.bin.index.json files, since they are unnecessary.
I changed the convert_hf_checkpoint.py to allow a single pytorch_model.bin file as the model description.
I added PY007/TinyLlama-1.1B-intermediate-step-480k-1T to the the model list since it's in the speculate_7B_int4.sh script. 

TinyLLama now works with the exception that weights_only would have to be changed to True on line 74 of convert_hf_checkpoint.py. I'll leave that up for discussion since it's less secure.