### PR TITLE
Set cuda device before init_process_group

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -260,7 +260,6 @@ def main(
     rank = maybe_init_dist()
     use_tp = rank is not None
     if use_tp:
-        torch.cuda.set_device(rank)
         if rank != 0:
             # only print on rank 0
             print = lambda *args, **kwargs: None

--- a/tp.py
+++ b/tp.py
@@ -42,6 +42,7 @@ def maybe_init_dist() -> Optional[int]:
         # not run via torchrun, no-op
         return None
 
+    torch.cuda.set_device(rank)
     dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
     return rank
 


### PR DESCRIPTION
To leverage the low latency intra-node comm in c10d (https://github.com/pytorch/pytorch/pull/114001), `torch.cuda.set_device()` needs to be invoked before `init_process_group()`.