### PR TITLE
Support Mixtral-8x7B

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -290,6 +290,8 @@ def main(
     if compile:
         if is_speculative and use_tp:
             torch._inductor.config.triton.cudagraph_trees = False # Bug with cudagraph trees in this case
+        if model.config.moe:
+            torch._inductor.assert_indirect_indexing = False
 
         if is_speculative:
             global model_forward, logits_to_prob

--- a/generate.py
+++ b/generate.py
@@ -291,7 +291,7 @@ def main(
         if is_speculative and use_tp:
             torch._inductor.config.triton.cudagraph_trees = False # Bug with cudagraph trees in this case
         if model.config.moe:
-            torch._inductor.assert_indirect_indexing = False
+            torch._inductor.config.assert_indirect_indexing = False
 
         if is_speculative:
             global model_forward, logits_to_prob

--- a/generate.py
+++ b/generate.py
@@ -209,8 +209,8 @@ def _load_model(checkpoint_path, device, precision, use_tp):
 
     if "int8" in str(checkpoint_path):
         print("Using int8 weight-only quantization!")
-        from quantize import WeightOnlyInt8QuantHandler
-        simple_quantizer = WeightOnlyInt8QuantHandler(model)
+        from quantize import WeightOnlyBit8QuantHandler
+        simple_quantizer = WeightOnlyBit8QuantHandler(model, torch.int8)
         model = simple_quantizer.convert_for_runtime()
 
     if "int4" in str(checkpoint_path):

--- a/model.py
+++ b/model.py
@@ -215,7 +215,7 @@ class ConditionalFeedForward(nn.Module):
         self.w2 = nn.Parameter(torch.empty(config.num_experts, config.intermediate_size, config.dim))
         self.w3 = nn.Parameter(torch.empty(config.num_experts, config.intermediate_size, config.dim))
 
-    @torch.compile(mode="reduce-overhead", fullgraph=True, dynamic=False)
+    @torch.compile(mode="reduce-overhead", fullgraph=True)
     def forward(self, x: Tensor, expert_indices: Tensor) -> Tensor:
         w1_weights = self.w1[expert_indices].transpose(-1, -2) # [T, A, D, D]
         w3_weights = self.w3[expert_indices].transpose(-1, -2) # [T, A, D, D]

--- a/model.py
+++ b/model.py
@@ -215,7 +215,6 @@ class ConditionalFeedForward(nn.Module):
         self.w2 = nn.Parameter(torch.empty(config.num_experts, config.intermediate_size, config.dim))
         self.w3 = nn.Parameter(torch.empty(config.num_experts, config.intermediate_size, config.dim))
 
-    @torch.compile(mode="reduce-overhead", fullgraph=True)
     def forward(self, x: Tensor, expert_indices: Tensor) -> Tensor:
         w1_weights = self.w1[expert_indices].transpose(-1, -2) # [T, A, D, D]
         w3_weights = self.w3[expert_indices].transpose(-1, -2) # [T, A, D, D]

--- a/quantize.py
+++ b/quantize.py
@@ -378,7 +378,6 @@ class ConditionalFeedForwardBit8(nn.Module):
         self.register_buffer("scales2", torch.empty(num_experts, intermediate_size, dtype=torch.bfloat16))
         self.register_buffer("scales3", torch.empty(num_experts, intermediate_size, dtype=torch.bfloat16))
 
-    @torch.compile(mode="reduce-overhead", fullgraph=True)
     def forward(self, x, expert_indices):
         w1_weights = (self.w1.to(x.dtype)[expert_indices] * self.scales1[expert_indices].to(x.dtype).unsqueeze(-1)).transpose(-1, -2)  # [T, A, D, D]
         w3_weights = (self.w3.to(x.dtype)[expert_indices] * self.scales3[expert_indices].to(x.dtype).unsqueeze(-1)).transpose(-1, -2)  # [T, A, D, D]

--- a/quantize.py
+++ b/quantize.py
@@ -378,7 +378,7 @@ class ConditionalFeedForwardBit8(nn.Module):
         self.register_buffer("scales2", torch.empty(num_experts, intermediate_size, dtype=torch.bfloat16))
         self.register_buffer("scales3", torch.empty(num_experts, intermediate_size, dtype=torch.bfloat16))
 
-    @torch.compile(mode="reduce-overhead", fullgraph=True, dynamic=False)
+    @torch.compile(mode="reduce-overhead", fullgraph=True)
     def forward(self, x, expert_indices):
         w1_weights = (self.w1.to(x.dtype)[expert_indices] * self.scales1[expert_indices].to(x.dtype).unsqueeze(-1)).transpose(-1, -2)  # [T, A, D, D]
         w3_weights = (self.w3.to(x.dtype)[expert_indices] * self.scales3[expert_indices].to(x.dtype).unsqueeze(-1)).transpose(-1, -2)  # [T, A, D, D]

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -3,6 +3,7 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
+import glob
 import json
 import re
 import sys
@@ -19,14 +20,11 @@ from model import ModelArgs
 
 
 @torch.inference_mode()
-def convert_hf_checkpoint(
+def convert_hf_checkpoint_llama(
     *,
     checkpoint_dir: Path = Path("checkpoints/meta-Transformer/Transformer-2-7b-chat-hf"),
     model_name: Optional[str] = None,
 ) -> None:
-    if model_name is None:
-        model_name = checkpoint_dir.name
-
     config = ModelArgs.from_name(model_name)
     print(f"Model config {config.__dict__}")
 
@@ -94,6 +92,84 @@ def convert_hf_checkpoint(
             del final_result[key.replace("wq", "wv")]
     print(f"Saving checkpoint to {checkpoint_dir / 'model.pth'}")
     torch.save(final_result, checkpoint_dir / "model.pth")
+
+
+# @torch.inference_mode()
+def convert_hf_checkpoint_mixtral(
+    *,
+    checkpoint_dir: Path = Path("checkpoints/mistralai/Mixtral-8x7B-v0.1"),
+    model_name: Optional[str] = None,
+) -> None:
+    config = ModelArgs.from_name(model_name)
+    print(f"Model config {config.__dict__}")
+
+    weight_map = {
+        "tok_embeddings.weight": "tok_embeddings.weight",
+        "layers.{}.attention.wq.weight": "layers.{}.attention.wq.weight",
+        "layers.{}.attention.wk.weight": "layers.{}.attention.wk.weight",
+        "layers.{}.attention.wv.weight": "layers.{}.attention.wv.weight",
+        "layers.{}.attention.wo.weight": "layers.{}.attention.wo.weight",
+        "layers.{}.block_sparse_moe.w1": "layers.{}.block_sparse_moe.cond_ffn.w1",
+        "layers.{}.block_sparse_moe.w2": "layers.{}.block_sparse_moe.cond_ffn.w2",
+        "layers.{}.block_sparse_moe.w3": "layers.{}.block_sparse_moe.cond_ffn.w3",
+        "layers.{}.block_sparse_moe.gate.weight": "layers.{}.block_sparse_moe.gate.weight",
+        "layers.{}.attention_norm.weight": "layers.{}.attention_norm.weight",
+        "layers.{}.ffn_norm.weight": "layers.{}.ffn_norm.weight",
+        "norm.weight": "norm.weight",
+        "output.weight": "output.weight",
+    }
+
+    pt_files = glob.glob(str(checkpoint_dir / "*.pt"))
+
+    merged_result = {}
+    for file in sorted(pt_files):
+        state_dict = torch.load(str(file), map_location="cpu", mmap=True, weights_only=True)
+        merged_result.update(state_dict)
+    final_result = {}
+    for key, value in merged_result.items():
+        if "layers" in key:
+            abstract_key = re.sub(r'.(\d+).', '.{}.', key)
+            layer_num = re.search(r'\d+', key).group(0)
+            new_key = weight_map[abstract_key]
+            if new_key is None:
+                continue
+            new_key = new_key.format(layer_num)
+        else:
+            new_key = weight_map[key]
+
+        final_result[new_key] = value
+
+    for key in tuple(final_result.keys()):
+        if "wq" in key:
+            q = final_result[key]
+            k = final_result[key.replace("wq", "wk")]
+            v = final_result[key.replace("wq", "wv")]
+            final_result[key.replace("wq", "wqkv")] = torch.cat([q, k, v])
+            del final_result[key]
+            del final_result[key.replace("wq", "wk")]
+            del final_result[key.replace("wq", "wv")]
+        if "w1" in key or "w2" in key or "w3" in key:
+            final_result[key] = final_result[key].reshape(config.num_experts, config.intermediate_size, config.dim).contiguous()
+        if "gate" in key:
+            final_result[key] = final_result[key].contiguous()
+
+    print(f"Saving checkpoint to {checkpoint_dir / 'model.pth'}")
+    torch.save(final_result, checkpoint_dir / "model.pth")
+
+
+def convert_hf_checkpoint(
+    *,
+    checkpoint_dir: Path = Path("checkpoints/meta-Transformer/Transformer-2-7b-chat-hf"),
+    model_name: Optional[str] = None,
+) -> None:
+    if model_name is None:
+        model_name = checkpoint_dir.name
+
+    if model_name == "Mixtral-8x7B-v0.1":
+        return convert_hf_checkpoint_mixtral(checkpoint_dir=checkpoint_dir, model_name=model_name)
+    else:
+        return convert_hf_checkpoint_llama(checkpoint_dir=checkpoint_dir, model_name=model_name)
+
 
 if __name__ == '__main__':
     import argparse

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -94,7 +94,7 @@ def convert_hf_checkpoint_llama(
     torch.save(final_result, checkpoint_dir / "model.pth")
 
 
-# @torch.inference_mode()
+@torch.inference_mode()
 def convert_hf_checkpoint_mixtral(
     *,
     checkpoint_dir: Path = Path("checkpoints/mistralai/Mixtral-8x7B-v0.1"),

--- a/tp.py
+++ b/tp.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 from torch import nn
 from torch.distributed import _functional_collectives as funcol
 
-from model import Attention, FeedForward, Transformer
+from model import Attention, FeedForward, MOEFeedForward, Transformer
 from quantize import WeightOnlyInt4Linear
 
 
@@ -46,6 +46,12 @@ def maybe_init_dist() -> Optional[int]:
     dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
     return rank
 
+rank = _get_rank()
+world_size = _get_world_size()
+
+def shard(x, dim):
+    assert x.size(dim=dim) % world_size == 0
+    return torch.tensor_split(x, world_size, dim=dim)[rank]
 
 def _apply_tp_linear(linear: nn.Linear, style: str, weight_splits: List[int] = []) -> None:
     rank = _get_rank()
@@ -62,9 +68,6 @@ def _apply_tp_linear(linear: nn.Linear, style: str, weight_splits: List[int] = [
 
     # ensure we can shard evenly
     assert getattr(linear, size_attr) % world_size == 0
-    def shard(x, dim):
-        assert x.size(dim=dim) % world_size == 0
-        return torch.tensor_split(x, world_size, dim=dim)[rank]
 
     def shard_qkv(qkv, dim, weight_splits):
         q, k, v = qkv.split(weight_splits, dim=dim)
@@ -117,6 +120,21 @@ def _apply_tp_ffn(mlp: FeedForward) -> None:
         output, "sum", list(range(world_size))))
 
 
+def _apply_tp_moe_ffn(mlp: MOEFeedForward) -> None:
+    mlp.cond_ffn.w1 = nn.Parameter(shard(mlp.cond_ffn.w1, 1), requires_grad=False)
+    mlp.cond_ffn.w3 = nn.Parameter(shard(mlp.cond_ffn.w3, 1), requires_grad=False)
+    mlp.cond_ffn.w2 = nn.Parameter(shard(mlp.cond_ffn.w2, 1), requires_grad=False)
+
+    if hasattr(mlp.cond_ffn, "scales1"):
+        mlp.cond_ffn.scales1 = nn.Parameter(shard(mlp.cond_ffn.scales1, 1), requires_grad=False)
+        mlp.cond_ffn.scales3 = nn.Parameter(shard(mlp.cond_ffn.scales3, 1), requires_grad=False)
+        mlp.cond_ffn.scales2 = nn.Parameter(shard(mlp.cond_ffn.scales2, 1), requires_grad=False)
+
+    world_size = _get_world_size()
+    mlp.cond_ffn.register_forward_hook(lambda _module, _input, output: funcol.all_reduce(
+        output, "sum", list(range(world_size))))
+
+
 def _apply_tp_attn(attn: Attention) -> None:
     assert hasattr(attn, "wqkv")
     assert hasattr(attn, "wo")
@@ -127,6 +145,7 @@ def _apply_tp_attn(attn: Attention) -> None:
 
     # overwrite
     world_size = _get_world_size()
+    assert attn.n_head % world_size == 0, "assert attn.n_head % world_size == 0"
     attn.n_head = attn.n_head // world_size
     attn.dim = attn.dim // world_size
     attn.head_dim = attn.dim // attn.n_head
@@ -148,5 +167,8 @@ def apply_tp(model: Transformer) -> None:
     _apply_tp_Transformer(model)
     for block in model.layers:
         # Apply to MLP
-        _apply_tp_ffn(block.feed_forward)
+        if model.config.moe:
+            _apply_tp_moe_ffn(block.block_sparse_moe)
+        else:
+            _apply_tp_ffn(block.feed_forward)
         _apply_tp_attn(block.attention)


### PR DESCRIPTION
This is based on #57. Please checkout https://github.com/yanboliang/gpt-fast/tree/mixtral-moe to try this.

Performance numbers (tokens/second):  
```
|                  |   1 GPU |    2 GPU  |    8 GPU    |
|------------------|---------|-----------|-------------|
|baseline(bfloat16)|    OOM  |    78.75  |   203.69    |
|        int8      |   56.04 |    99.91  |   218.48    |
```
Note: Benchmarks run on an 8xA100-80GB, power limited to 330W with a hybrid cube mesh topology. 

How to reproduce it:
```
export MODEL_REPO=mistralai/Mixtral-8x7B-v0.1
# Download model weights
python scripts/download.py --repo_id $MODEL_REPO
# Convert to gpt-fast supported format
python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/$MODEL_REPO
# Generate int8 quantization model weights
python quantize.py --checkpoint_path checkpoints/$MODEL_REPO/model.pth --mode int8
# Test tp=8
ENABLE_INTRA_NODE_COMM=1 torchrun --standalone --nproc_per_node=8 generate.py --compile --compile_prefill --checkpoint_path checkpoints/$MODEL_REPO/model.pth
# Test single GPU + int8 model
python generate.py --compile --compile_prefill --checkpoint_path checkpoints/$MODEL_REPO/model_int8.pth
```
