### PR TITLE
Updating eval for lm_eval 0.4 and 0.3

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -24,12 +24,13 @@ from model import Transformer
 
 try:
     import lm_eval
+    lm_eval_available = True
 except:
-    lm_eval = False
+    lm_eval_available = False
 
 from generate import _load_model, encode_tokens, model_forward
 
-if lm_eval:
+if lm_eval_available:
     try: # lm_eval version 0.4
         from lm_eval.models.huggingface import HFLM as eval_wrapper
         from lm_eval.tasks import get_task_dict

--- a/eval.py
+++ b/eval.py
@@ -18,25 +18,30 @@ torch._inductor.config.epilogue_fusion = False
 torch._inductor.config.triton.cudagraphs = True
 torch._dynamo.config.cache_size_limit = 100000
 
-# support running without installing as a package
-wd = Path(__file__).parent.parent.resolve()
-sys.path.append(str(wd))
-
-# hacky path setup for lm-evaluation-harness
-import os
-import sys
-
 from sentencepiece import SentencePieceProcessor
 
 from model import Transformer
 
-lm_evaluation_harness_path = '/'.join(
-    os.getcwd().split('/')[:-1] + ['lm-evaluation-harness'])
-sys.path.insert(0, lm_evaluation_harness_path)
-import lm_eval
-import main as lm_evaluation_harness_main
+try:
+    import lm_eval
+except:
+    lm_eval = False
 
 from generate import _load_model, encode_tokens, model_forward
+
+if lm_eval:
+    try: # lm_eval version 0.4
+        from lm_eval.models.huggingface import HFLM as eval_wrapper
+        from lm_eval.tasks import get_task_dict
+        from lm_eval.evaluator import evaluate
+        lm_eval.tasks.initialize_tasks()
+    except: #lm_eval version 0.3
+        from lm_eval import base
+        from lm_eval import tasks
+        from lm_eval import evaluator
+        eval_wrapper=base.BaseLM
+        get_task_dict=tasks.get_task_dict
+        evaluate=evaluator.evaluate
 
 
 def setup_cache_padded_seq_input_pos_max_seq_length_for_prefill(
@@ -77,7 +82,7 @@ def setup_cache_padded_seq_input_pos_max_seq_length_for_prefill(
 
     return seq, input_pos, max_seq_length
 
-class GPTFastEvalWrapper(lm_eval.base.BaseLM):
+class GPTFastEvalWrapper(eval_wrapper):
     """
     A wrapper class for GPTFast, providing integration with the lm-evaluation-harness library.
     """
@@ -113,7 +118,7 @@ class GPTFastEvalWrapper(lm_eval.base.BaseLM):
     def device(self):
         return self._device
 
-    def tok_encode(self, string: str):
+    def tok_encode(self, string: str, **kwargs):
         encoded = encode_tokens(self._tokenizer,
             string, bos=True, device=self._device)
         # encoded is a pytorch tensor, but some internal logic in the
@@ -176,9 +181,9 @@ def eval(
     if 'hendrycks_test' in tasks:
         tasks.remove('hendrycks_test')
         tasks += [x for x in lm_eval.tasks.hendrycks_test.create_all_tasks().keys()]
-    task_dict = lm_eval.tasks.get_task_dict(tasks)
+    task_dict = get_task_dict(tasks)
 
-    eval_results = lm_eval.evaluator.evaluate(
+    eval_results = evaluate(
         model_eval_wrapper,
         task_dict,
         limit=limit,

--- a/quantize.py
+++ b/quantize.py
@@ -12,7 +12,8 @@ import torch.nn.functional as F
 from sentencepiece import SentencePieceProcessor
 
 try:
-    from GPTQ import GenericGPTQRunner, InputRecorder, lm_eval
+    from GPTQ import GenericGPTQRunner, InputRecorder
+    from eval import get_task_dict, evaluate
 except:
     pass
 
@@ -248,9 +249,9 @@ class GPTQQuantHandler(QuantHandler):
             calibration_seq_length,
             pad_calibration_inputs,
         )
-        task_dict = lm_eval.tasks.get_task_dict(calibration_tasks)
+        task_dict = get_task_dict(calibration_tasks)
         print("Obtaining GPTQ calibration inputs on: ", calibration_tasks)
-        lm_eval.evaluator.evaluate(
+        evaluate(
             input_recorder,
             task_dict,
             limit=calibration_limit,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #83
* #97
* __->__ #91

Summary: 0.4 broke BC, this fixes regardless of version

Test Plan: (on both versions and without lm_eval installed)

python quantize.py --mode int8

(on both versions)

python eval.py --tasks wikitext

wikitext: {'word_perplexity,none': 12.212490471702079, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.59675331009031, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6751414412399839, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}

For model checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth
wikitext: {'word_perplexity': 12.212490471702079, 'byte_perplexity': 1.59675331009031, 'bits_per_byte': 0.6751414412399839}

Reviewers:

Subscribers:

Tasks:

Tags: