### PR TITLE
[quant] Add int8 per token dynamic quant + int4 per group quant for ExecuTorch

### DIFF
--- a/GPTQ.py
+++ b/GPTQ.py
@@ -207,6 +207,7 @@ class GenericGPTQRunner(fx.Interpreter):
         combine_qparams_list_func,
         make_names_and_values_dict_func,
         skip_layer_func,
+        dyn_quant_func = None,
     ):
         # these functions need to already be curried with all inputs other than weight, qparams
         self.get_qparams_func = (
@@ -227,6 +228,8 @@ class GenericGPTQRunner(fx.Interpreter):
 
         self.make_names_and_values_dict_func = make_names_and_values_dict_func  # accepts [2d quantized tensor], [qparams], returns a dict of names, values to put in state_dict
         # note any final packing for storage should happen here
+
+        self.dyn_quant_func = dyn_quant_func
         return self
 
     def run(self):
@@ -299,6 +302,8 @@ class GenericGPTQRunner(fx.Interpreter):
                 quantize_linear
             ):  # calculate H instead of output (will run the linear eventually with updated weight)
                 x = cur_args[0].float()
+                if self.dyn_quant_func is not None:
+                    x = self.dyn_quant_func(x)
                 shape = x.shape
                 n = 1 if len(shape) == 2 else shape[0]
                 H *= total_batches / (total_batches + n)

--- a/et_quantize.py
+++ b/et_quantize.py
@@ -212,7 +212,7 @@ def get_group_qparams_symmetric(w, n_bit=4, groupsize=128, precision=torch.float
     )
 
 
-def pack_scales_and_zeros(scales, zeros, precision=torch.float16):
+def pack_scales_and_zeros(scales, zeros, precision=torch.bfloat16):
     assert scales.shape == zeros.shape
     assert scales.dtype == precision
     assert zeros.dtype == precision
@@ -331,13 +331,14 @@ def group_quantize_tensor_symmetric(w, n_bit=4, group_size=128):
         w, scales, zeros, min_int, max_int, torch.int8, group_size
     )
 
-    scales_and_zeros = pack_scales_and_zeros(scales, zeros)
+    # TODO: add precision arg
+    scales_and_zeros = pack_scales_and_zeros(scales, zeros, torch.float16)
     return w_int8, scales_and_zeros
 
 
 quantized_decomposed_lib.define(
     "dequantize_per_channel_group(Tensor input, Tensor scales, Tensor zero_points, int quant_min, "
-    "int quant_max, ScalarType dtype, int group_size) -> Tensor"
+    "int quant_max, ScalarType dtype, int group_size, ScalarType out_dtype) -> Tensor"
 )
 
 
@@ -353,7 +354,8 @@ def dequantize_per_channel_group(
     quant_min: int,
     quant_max: int,
     dtype: torch.dtype,
-    group_size=128,
+    group_size: int = 128,
+    out_dtype: torch.dtype = torch.float16,
 ):
     """Groupwise dequantization within each channel for an 2-d Tensor using the quantization parameters
     to map from floating point to quantized values. This means for each row of a 2-d Tensor
@@ -383,20 +385,20 @@ def dequantize_per_channel_group(
     w_int8_grouped = w_int8.reshape(-1, group_size)
     scales = scales.reshape(-1, 1)
     zero_points = zero_points.reshape(-1, 1)
-    w_dq = w_int8_grouped.sub(zero_points).mul(scales).reshape_as(w_int8)
+    w_dq = w_int8_grouped.sub(zero_points).mul(scales).reshape_as(w_int8).to(out_dtype)
     return w_dq
 
 
 def group_dequantize_tensor_symmetric(
-    w_int8, scales_and_zeros, n_bit=4, group_size=128
+    w_int8, scales_and_zeros, group_size=128
 ):
     # TODO: remove this
     scales, zero_points = unpack_scales_and_zeros(scales_and_zeros)
     n_bit = 4
     quant_min = -(2 ** (n_bit - 1))
     quant_max = 2 ** (n_bit - 1) - 1
-    return torch.ops.quantized_decomposed.quantize_per_channel_group(
-        w_int8, scales, zero_points, quant_min, quant_max, torch.uint4, group_size
+    return torch.ops.quantized_decomposed.dequantize_per_channel_group(
+        w_int8, scales, zero_points, quant_min, quant_max, torch.int8, group_size, torch.float16
     )
 
 
@@ -463,8 +465,7 @@ def linear_forward_8da4w(x, weight_int8, scales_and_zeros, out_features, groupsi
     origin_x_size = x.size()
     x = x.reshape(-1, origin_x_size[-1])
     scales_and_zeros = scales_and_zeros.to(torch.float)
-    scales, zeros = unpack_scales_and_zeros(scales_and_zeros)
-    w_dq = group_dequantize_tensor_from_qparams(weight_int8, scales, zeros, groupsize=groupsize)
+    w_dq = group_dequantize_tensor_symmetric(weight_int8, scales_and_zeros, groupsize)
     x = x.to(torch.float16)
     w_dq = w_dq.to(torch.float16)
     c = torch.ops.aten.linear(x, w_dq)

--- a/et_quantize.py
+++ b/et_quantize.py
@@ -1,0 +1,473 @@
+# Note: This is an experimental file to unblock people to do evaluation on quantization
+# options that's compatible with executorch, things in this file will move around to the final
+# location after the stack is more stablized
+
+import torch
+
+################ These will be moved to pytorch or torchao later ##############
+# copied pasted from executorch/examples/models/llama2/quantize.py
+from torch.ao.quantization.fx._decomposed import (
+    _quant_min_max_bounds_check,
+    quantized_decomposed_lib,
+)
+from torch.library import impl
+import math
+from typing import Tuple
+
+quantized_decomposed_lib.define(
+    "choose_qparams_per_token(Tensor input, ScalarType dtype) -> (Tensor, Tensor)"
+)
+
+
+@impl(
+    quantized_decomposed_lib,
+    "choose_qparams_per_token",
+    "CompositeExplicitAutograd",
+)
+def choose_qparams_per_token(
+    input: torch.Tensor,
+    dtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Choose quantization parameters for per token quantization. This means for a N dimension Tensor
+    (M1, M2, ...Mn, N), we calculate scales/zero_points for each N elements and quantize
+    every N elements with the same quantization parameter. The dimension for scales/zero_points
+    will be (M1 * M2 ... * Mn)
+
+    Args:
+       input (torch.Tensor): original float32/float16 Tensor
+       dtype (torch.dtype): dtype (e.g. torch.uint8) for input Tensor
+
+    Returns:
+        scales and zero_points, both float32 Tensors
+    """
+
+    scales = input.abs().amax(dim=-1, keepdim=True)
+    if scales.dtype == torch.float16:
+        scales = (
+            scales.float()
+        )  # want float scales to avoid overflows for fp16, (bf16 has wide enough range)
+    if dtype == torch.int8:
+        n_bits = 8
+        quant_max = 2 ** (n_bits - 1) - 1
+    else:
+        raise Exception(f"unsupported dtype in choose_qparams_per_token: {dtype}")
+
+    scales = scales.clamp(min=1e-5).div(quant_max)
+    zero_points = torch.zeros_like(scales)
+    return scales, zero_points
+
+
+@impl(
+    quantized_decomposed_lib,
+    "choose_qparams_per_token",
+    "Meta",
+)
+def choose_qparams_per_token_meta(
+    input: torch.Tensor,
+    dtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    size = (1, input.size(-1))
+    return torch.empty(size, dtype=torch.double, device=input.device), torch.empty(
+        size, dtype=torch.int64, device=input.device
+    )
+
+
+def _per_token_quant_qparam_dim_check(input, scales, zero_points):
+    num_tokens = math.prod(list(input.size())[:-1])
+    assert num_tokens == scales.size(0)
+    assert num_tokens == zero_points.size(0)
+
+
+quantized_decomposed_lib.define(
+    "quantize_per_token(Tensor input, Tensor scales, Tensor zero_points, "
+    "int quant_min, int quant_max, ScalarType dtype) -> Tensor"
+)
+
+
+@impl(quantized_decomposed_lib, "quantize_per_token", "CompositeExplicitAutograd")
+def quantize_per_token(
+    input: torch.Tensor,
+    scales: torch.Tensor,
+    zero_points: torch.Tensor,
+    quant_min: int,
+    quant_max: int,
+    dtype: torch.dtype,
+):
+    """Per token quantization for the Tensor using the quantization parameters to map
+    from floating point to quantized values. This means for a N dimension Tensor
+    (M1, M2, ...Mn, N), we calculate scales/zero_points for each N elements and quantize
+    every N elements with the same quantization parameter. The dimension for scales/zero_points
+    will be (M1 * M2 ... * Mn)
+
+    Args:
+       input (torch.Tensor): original float32 or bfloat16 Tensor
+       scales (float32 torch.Tensor): quantization parameter for per token affine quantization
+       zero_points (int32 torch.Tensor): quantization parameter for per token affine quantization
+       quant_min (int): minimum quantized value for output Tensor
+       quant_max (int): maximum quantized value for output Tensor
+       dtype (torch.dtype): requested dtype (e.g. torch.uint8) for output Tensor
+
+    Returns:
+       Tensor with requested dtype (e.g. torch.uint8), note the quantization parameters
+       are not stored in the Tensor, we are storing them in function arguments instead
+    """
+    _quant_min_max_bounds_check(quant_min, quant_max, dtype)
+    # _per_token_quant_qparam_dim_check(input, scales, zero_points)
+    # TODO: dim check
+    input = torch.round(input / scales).clamp(quant_min, quant_max).to(dtype)
+    input = input + zero_points
+    return input
+
+
+@impl(quantized_decomposed_lib, "quantize_per_token", "Meta")
+def quantize_per_token_meta(
+    input: torch.Tensor,
+    scales: torch.Tensor,
+    zero_points: torch.Tensor,
+    quant_min: int,
+    quant_max: int,
+    dtype: torch.dtype,
+):
+    _quant_min_max_bounds_check(quant_min, quant_max, dtype)
+    return torch.empty_like(input, dtype=dtype)
+
+
+quantized_decomposed_lib.define(
+    "dequantize_per_token(Tensor input, Tensor scales, Tensor zero_points, "
+    "int quant_min, int quant_max, ScalarType dtype) -> Tensor"
+)
+
+
+@impl(quantized_decomposed_lib, "dequantize_per_token", "CompositeExplicitAutograd")
+def dequantize_per_token(
+    input: torch.Tensor,
+    scales: torch.Tensor,
+    zero_points: torch.Tensor,
+    quant_min: int,
+    quant_max: int,
+    dtype: torch.dtype,
+):
+    """Per token dequantization for the Tensor using the quantization parameters to map
+    from floating point to quantized values. This means for a N dimension Tensor
+    (M1, M2, ...Mn, N), we calculate scales/zero_points for each N elements and quantize
+    every N elements with the same quantization parameter. The dimension for scales/zero_points
+    will be (M1 * M2 ... * Mn)
+
+    Args:
+       input (torch.Tensor): quantized Tensor (uint8, int8 etc.)
+       scales (float32 torch.Tensor): quantization parameter for per token affine quantization
+       zero_points (int32 torch.Tensor): quantization parameter for per token affine quantization
+       quant_min (int): minimum quantized value for input Tensor
+       quant_max (int): maximum quantized value for input Tensor
+       dtype (torch.dtype): dtype (e.g. torch.uint8) for input Tensor
+
+    Returns:
+       dequantized float32 Tensor
+    """
+    input = input - zero_points
+    input = input.to(torch.float32) * scales
+    return input
+
+
+@impl(quantized_decomposed_lib, "dequantize_per_token", "Meta")
+def dequantize_per_token_meta(
+    input: torch.Tensor,
+    scales: torch.Tensor,
+    zero_points: torch.Tensor,
+    quant_min: int,
+    quant_max: int,
+    dtype: torch.dtype,
+):
+    _quant_min_max_bounds_check(quant_min, quant_max, dtype)
+    # TODO: support fp16
+    return torch.empty_like(input, dtype=torch.float32)
+
+
+def get_group_qparams_symmetric(w, n_bit=4, groupsize=128, precision=torch.float16):
+    # needed for GPTQ with padding
+    if groupsize > w.shape[-1]:
+        groupsize = w.shape[-1]
+    assert groupsize > 1
+    assert w.shape[-1] % groupsize == 0
+    assert w.dim() == 2
+
+    to_quant = w.reshape(-1, groupsize)
+    assert torch.isnan(to_quant).sum() == 0
+
+    max_val = to_quant.amax(dim=1, keepdim=True)
+    min_val = to_quant.amin(dim=1, keepdim=True)
+    min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
+    max_val_pos = torch.max(max_val, torch.zeros_like(max_val))
+
+    max_val_abs = torch.max(-min_val_neg, max_val_pos)
+    max_int = 2 ** (n_bit - 1) - 1
+    min_int = -(2 ** (n_bit - 1))
+
+    scales = max_val_abs / (float(max_int - min_int) / 2)
+    scales = torch.max(scales, torch.full_like(scales, torch.finfo(torch.float32).eps))
+    # TODO: make sure abs(scales) is not too small?
+    zeros = torch.full_like(scales, 0)
+    return scales.to(precision).reshape(w.shape[0], -1), zeros.to(precision).reshape(
+        w.shape[0], -1
+    )
+
+
+def pack_scales_and_zeros(scales, zeros, precision=torch.float16):
+    assert scales.shape == zeros.shape
+    assert scales.dtype == precision
+    assert zeros.dtype == precision
+    return (
+        torch.cat(
+            [
+                scales.reshape(scales.size(0), scales.size(1), 1),
+                zeros.reshape(zeros.size(0), zeros.size(1), 1),
+            ],
+            2,
+        )
+        .transpose(0, 1)
+        .contiguous()
+    )
+
+
+def unpack_scales_and_zeros(scales_and_zeros):
+    assert len(scales_and_zeros.shape) == 3 and scales_and_zeros.shape[2] == 2
+    # why is this float?
+    # assert scales_and_zeros.dtype == torch.float
+    return torch.split(scales_and_zeros.transpose(0, 1), 1, 2)
+
+
+quantized_decomposed_lib.define(
+    "quantize_per_channel_group(Tensor input, Tensor scales, Tensor zero_points, int quant_min, "
+    "int quant_max, ScalarType dtype, int group_size) -> Tensor"
+)
+
+
+# TODO: dtype is ignored for now
+@impl(
+    quantized_decomposed_lib, "quantize_per_channel_group", "CompositeExplicitAutograd"
+)
+def quantize_per_channel_group(
+    input: torch.Tensor,
+    scales: torch.Tensor,
+    zero_points: torch.Tensor,
+    quant_min: int,
+    quant_max: int,
+    dtype: torch.dtype,
+    group_size=128,
+):
+    assert group_size > 1
+    # needed for GPTQ single column quantize
+    if group_size > input.shape[-1] and scales.shape[-1] == 1:
+        group_size = input.shape[-1]
+
+    assert input.shape[-1] % group_size == 0
+    assert input.dim() == 2
+
+    # TODO: check for dtype, currently we can't express torch.int4 so it's omitted
+    to_quant = input.reshape(-1, group_size)
+    assert torch.isnan(to_quant).sum() == 0
+
+    scales = scales.reshape(-1, 1)
+    zero_points = zero_points.reshape(-1, 1)
+
+    input_int8 = (
+        to_quant.div(scales)
+        .add(zero_points)
+        .round()
+        .clamp_(quant_min, quant_max)
+        .to(dtype)
+        .reshape_as(input)
+    )
+
+    return input_int8
+
+
+@impl(quantized_decomposed_lib, "quantize_per_channel_group", "Meta")
+def quantize_per_channel_group(
+    input: torch.Tensor,
+    scales: torch.Tensor,
+    zero_points: torch.Tensor,
+    quant_min: int,
+    quant_max: int,
+    dtype: torch.dtype,
+    group_size=128,
+):
+    """Groupwise quantization within each channel for an 2-d Tensor using the quantization parameters
+    to map from floating point to quantized values. This means for each row of a 2-d Tensor
+    (M, N), we calculate scales/zero_points for each `group_size` elements
+    and quantize every `group_size` elements with the same quantization parameter.
+    The dimension for scales/zero_points will be (M * ceil(N, group_size),)
+
+    Args:
+       input (torch.Tensor): original float32 or bfloat16 Tensor
+       scales (float32 torch.Tensor): quantization parameter for per channel group affine quantization
+       zero_points (int32 torch.Tensor): quantization parameter for per channel group affine quantization
+       quant_min (int): minimum quantized value for output Tensor
+       quant_max (int): maximum quantized value for output Tensor
+       dtype (torch.dtype): requested dtype (e.g. torch.uint8) for output Tensor
+
+    Returns:
+       Tensor with requested dtype (e.g. torch.uint8), note the quantization parameters
+       are not stored in the Tensor, we are storing them in function arguments instead
+    """
+    assert group_size > 1
+    # needed for GPTQ single column quantize
+    if group_size > input.shape[-1] and scales.shape[-1] == 1:
+        group_size = input.shape[-1]
+
+    assert input.shape[-1] % group_size == 0
+    assert input.dim() == 2
+    return torch.empty_like(input, dtype=dtype)
+
+
+def group_quantize_tensor_symmetric(w, n_bit=4, group_size=128):
+    scales, zeros = get_group_qparams_symmetric(w, n_bit, group_size)
+    n_bit = 4
+    max_int = 2 ** (n_bit - 1) - 1
+    min_int = -(2 ** (n_bit - 1))
+    # TODO: currently we don't know how to express torch.int4, we'll
+    # add torch.int4 to core later
+    w_int8 = torch.ops.quantized_decomposed.quantize_per_channel_group(
+        w, scales, zeros, min_int, max_int, torch.int8, group_size
+    )
+
+    scales_and_zeros = pack_scales_and_zeros(scales, zeros)
+    return w_int8, scales_and_zeros
+
+
+quantized_decomposed_lib.define(
+    "dequantize_per_channel_group(Tensor input, Tensor scales, Tensor zero_points, int quant_min, "
+    "int quant_max, ScalarType dtype, int group_size) -> Tensor"
+)
+
+
+@impl(
+    quantized_decomposed_lib,
+    "dequantize_per_channel_group",
+    "CompositeExplicitAutograd",
+)
+def dequantize_per_channel_group(
+    w_int8: torch.Tensor,
+    scales: torch.Tensor,
+    zero_points: torch.Tensor,
+    quant_min: int,
+    quant_max: int,
+    dtype: torch.dtype,
+    group_size=128,
+):
+    """Groupwise dequantization within each channel for an 2-d Tensor using the quantization parameters
+    to map from floating point to quantized values. This means for each row of a 2-d Tensor
+    (M, N), we calculate scales/zero_points for each `group_size` elements
+    and quantize every `group_size` elements with the same quantization parameter.
+    The dimension for scales/zero_points will be (M * ceil(N, group_size),)
+
+    Args:
+       input (torch.Tensor): quantized Tensor (uint8/int8 etc.)
+       scales (float32 torch.Tensor): quantization parameter for per channel group affine quantization
+       zero_points (int32 torch.Tensor): quantization parameter for per channel group affine quantization
+       quant_min (int): minimum quantized value for input Tensor
+       quant_max (int): maximum quantized value for input Tensor
+       dtype (torch.dtype): dtype (e.g. torch.uint8) for input Tensor
+
+    Returns:
+       dequantized float32 Tensor
+    """
+
+    assert group_size > 1
+    # needed for GPTQ single column dequantize
+    if group_size > w_int8.shape[-1] and scales.shape[-1] == 1:
+        group_size = w_int8.shape[-1]
+    assert w_int8.shape[-1] % group_size == 0
+    assert w_int8.dim() == 2
+
+    w_int8_grouped = w_int8.reshape(-1, group_size)
+    scales = scales.reshape(-1, 1)
+    zero_points = zero_points.reshape(-1, 1)
+    w_dq = w_int8_grouped.sub(zero_points).mul(scales).reshape_as(w_int8)
+    return w_dq
+
+
+def group_dequantize_tensor_symmetric(
+    w_int8, scales_and_zeros, n_bit=4, group_size=128
+):
+    # TODO: remove this
+    scales, zero_points = unpack_scales_and_zeros(scales_and_zeros)
+    n_bit = 4
+    quant_min = -(2 ** (n_bit - 1))
+    quant_max = 2 ** (n_bit - 1) - 1
+    return torch.ops.quantized_decomposed.quantize_per_channel_group(
+        w_int8, scales, zero_points, quant_min, quant_max, torch.uint4, group_size
+    )
+
+
+def down_size(size):
+    assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
+    return (*size[:-1], size[-1] // 2)
+
+
+def up_size(size):
+    return (*size[:-1], size[-1] * 2)
+
+
+quantized_decomposed_lib.define("pack_int4_from_int8(Tensor int8_data) -> Tensor")
+
+
+@impl(quantized_decomposed_lib, "pack_int4_from_int8", "CompositeExplicitAutograd")
+def pack_int4_from_int8(int8_data: torch.Tensor) -> torch.Tensor:
+    # converting to uint8 for operations
+    shape = int8_data.shape
+    assert shape[-1] % 2 == 0
+    int8_data = int8_data.contiguous().view(-1)
+    return (int8_data[::2] << 4 | int8_data[1::2]).view(down_size(shape))
+
+
+quantized_decomposed_lib.define("unpack_int4_to_int8(Tensor int8_data) -> Tensor")
+
+
+@impl(quantized_decomposed_lib, "unpack_int4_to_int8", "CompositeExplicitAutograd")
+def unpack_int4_to_int8(int8_data: torch.Tensor) -> torch.Tensor:
+    """Get the original weight from the normalized float weight format"""
+    # since we are using int8 we will decode 2 entries per byte
+    # Shift elements down 4 and select out the bottom 4 bits
+    shape = int8_data.shape
+    first_elements = (int8_data >> 4).to(torch.int8)
+    second_elements = (int8_data & 0b1111).to(torch.int8)
+    return torch.stack([first_elements, second_elements], dim=-1).view(up_size(shape))
+
+################ These will be moved to pytorch or torchao later ##############
+
+def per_token_dynamic_quant(input: torch.Tensor) -> torch.Tensor:
+    orig_dtype = input.dtype
+    (
+        scales,
+        zero_points,
+    ) = torch.ops.quantized_decomposed.choose_qparams_per_token(input, torch.int8)
+
+    # TODO: get these from torch.int8
+    quant_min = -128
+    quant_max = 127
+    input = torch.ops.quantized_decomposed.quantize_per_token(
+        input, scales, zero_points, quant_min, quant_max, torch.int8
+    )
+    input = torch.ops.quantized_decomposed.dequantize_per_token(
+        input, scales, zero_points, quant_min, quant_max, torch.int8
+    )
+    input = input.to(orig_dtype)
+    return input
+
+def linear_forward_8da4w(x, weight_int8, scales_and_zeros, out_features, groupsize):
+    """8 bit per token dynamic quantization for activation and 4 bit per channel group quantization
+    for weight
+    """
+    x = per_token_dynamic_quant(x)
+    origin_x_size = x.size()
+    x = x.reshape(-1, origin_x_size[-1])
+    scales_and_zeros = scales_and_zeros.to(torch.float)
+    scales, zeros = unpack_scales_and_zeros(scales_and_zeros)
+    w_dq = group_dequantize_tensor_from_qparams(weight_int8, scales, zeros, groupsize=groupsize)
+    x = x.to(torch.float16)
+    w_dq = w_dq.to(torch.float16)
+    c = torch.ops.aten.linear(x, w_dq)
+    new_shape = origin_x_size[:-1] + (out_features,)
+    c = c.reshape(new_shape)
+    return c

--- a/et_quantize.py
+++ b/et_quantize.py
@@ -283,7 +283,7 @@ def quantize_per_channel_group(
 
 
 @impl(quantized_decomposed_lib, "quantize_per_channel_group", "Meta")
-def quantize_per_channel_group(
+def quantize_per_channel_group_meta(
     input: torch.Tensor,
     scales: torch.Tensor,
     zero_points: torch.Tensor,

--- a/eval.py
+++ b/eval.py
@@ -216,7 +216,8 @@ def main(
     assert tokenizer_path.is_file(), tokenizer_path
 
     device = 'cuda'
-    precision = torch.bfloat16
+    # precision = torch.bfloat16
+    precision = torch.float16
 
     print("Loading model ...")
     t0 = time.time()

--- a/generate.py
+++ b/generate.py
@@ -223,7 +223,16 @@ def _load_model(checkpoint_path, device, precision, use_tp):
         simple_quantizer = WeightOnlyInt8QuantHandler(model)
         model = simple_quantizer.convert_for_runtime()
 
-    if "int4" in str(checkpoint_path):
+    elif "8da4w-gptq" in str(checkpoint_path):
+        print("Using int8 per token dynamic quant and int4 per group weight quant gptq quantization!")
+        path_comps = checkpoint_path.name.split(".")
+        assert path_comps[-2].startswith("g")
+        groupsize = int(path_comps[-2][1:])
+        from quantize import Int8DynActInt4WeightGPTQQuantHandler
+        simple_quantizer = Int8DynActInt4WeightGPTQQuantHandler(model, groupsize)
+        model = simple_quantizer.convert_for_runtime()
+
+    elif "int4" in str(checkpoint_path):
         print("Using int4 quantization!")
         path_comps = checkpoint_path.name.split(".")
         assert path_comps[-2].startswith("g")

--- a/quantize.py
+++ b/quantize.py
@@ -553,7 +553,7 @@ class Int8DynActInt4WeightLinear(torch.nn.Module):
         input = F.pad(input, pad=(0, self.in_features - self.origin_in_features))
         return linear_forward_8da4w(
             input,
-            self.weight, self.scales_and_zeros, self.out_features, self.groupsize
+            self.weight, self.scales_and_zeros, self.out_features, self.groupsize, self.precision
         )
 
 
@@ -573,7 +573,7 @@ class Int8DynActInt4WeightGPTQQuantHandler(GPTQQuantHandler):
         self.quantize_func = lambda w, qparams: \
             torch.ops.quantized_decomposed.quantize_per_channel_group(w, qparams[0], qparams[1], quant_min, quant_max, torch.int8, groupsize)
         self.dequantize_func = lambda q, qparams: \
-            torch.ops.quantized_decomposed.dequantize_per_channel_group(q, qparams[0], qparams[1], quant_min, quant_max, torch.int8, groupsize, out_dtype=self.precision)
+            torch.ops.quantized_decomposed.dequantize_per_channel_group(q, qparams[0], qparams[1], quant_min, quant_max, torch.int8, groupsize, self.precision)
         self.combine_qparams_list_func = lambda qparams_list: \
             [torch.cat(x, dim=1) for x in zip(*qparams_list)]
         # skip unless padding_allowed=True or its correctly sized


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102

Summary:
att

Adding this for accuracy evaluation, we also added this in executorch repo and we'll dedup later

Test Plan:

quantization:
```
python quantize.py --checkpoint_path checkpoints/$MODEL_REPO/model.pth --mode 8da4w-gptq --calibration_tasks wikitext --calibration_limit 5
```
this finished in 20+ min in my machine
if you change calibration_limit to 1, then it can be finished in 10+ min, but expect worse quality since we do less calibration (use this for debugging a new quantization experiment)

evaluation:
```
python eval.py --checkpoint_path checkpoints/$MODEL_REPO/model_8da4w-gptq.g32.pth --tasks wikitext
```
This should be fast, the result I'm getting is:
```
wikitext: {'word_perplexity,none': 10.15655335078972, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.5726497149737177, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6531973670369153, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
```

Reviewers:

Subscribers:

Tasks:

Tags: