### PR TITLE
Fixing synchronization issue when non-zero GPU is used as a device

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -15,7 +15,7 @@ import torch._inductor.config
 
 def device_sync(device):
     if "cuda" in device:
-        torch.cuda.synchronize()
+        torch.cuda.synchronize(device)
     elif "cpu" in device:
         pass
     else:

--- a/mixtral-moe/generate.py
+++ b/mixtral-moe/generate.py
@@ -15,7 +15,7 @@ import torch._inductor.config
 
 def device_sync(device):
     if "cuda" in device:
-        torch.cuda.synchronize()
+        torch.cuda.synchronize(device)
     elif "cpu" in device:
         pass
     else:


### PR DESCRIPTION
If --device='cuda:1' (or any other non-zero cuda device) is used for generate.py then device_sync(device) is not working correctly, since torch.cuda.synchronize() is called w/o params and torch.cuda.current_device() is still 'cuda:0'. Thus, adding the 'device' as a parameter for torch.cuda.synchronize() call.