### PR TITLE
Set torch._dynamo.config.max_loop_unroll_nodes to 7500

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -25,6 +25,8 @@ def device_sync(device):
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
 torch._inductor.config.fx_graph_cache = True # Experimental feature to reduce compilation times, will be on by default in future
+if hasattr(torch._dynamo.config, "max_loop_unroll_nodes"):
+    torch._dynamo.config.max_loop_unroll_nodes = 7500
 
 
 # support running without installing as a package


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/120023 recently introduced this config with a default value of 5000. This caused llama 70B TP compilation to fail with the "unrolled loop getting too big" error.

Setting it to 7500 which is the smallest incremental of 500 that makes llama 70B TP work.