### PR TITLE
Do not attempt to import distributed primitives on MacOS

### DIFF
--- a/tp.py
+++ b/tp.py
@@ -9,7 +9,11 @@ from typing import List, Optional
 import torch
 import torch.distributed as dist
 from torch import nn
-from torch.distributed import _functional_collectives as funcol
+if os.uname().sysname != "Darwin":
+    from torch.distributed import _functional_collectives as funcol
+else:
+    # Distributed is not supported on MacOS
+    funcol = None
 
 from model import Attention, FeedForward, Transformer
 from quantize import WeightOnlyInt4Linear


### PR DESCRIPTION
As PyTorch is by default compiled without distributed support on Mac