### PR TITLE
Add CPU support in mixtral-moe for int8 woq

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -238,7 +238,10 @@ def main(
     if compile:
         global model_forward
         model_forward = torch.compile(model_forward,  mode="reduce-overhead", dynamic=True, fullgraph=True)
-        torch._inductor.config.coordinate_descent_tuning = True
+        if "cpu" in device:
+            torch._inductor.config.coordinate_descent_tuning = False
+        else:
+            torch._inductor.config.coordinate_descent_tuning = True
 
     t1 = time.time()
     result = eval(

--- a/generate.py
+++ b/generate.py
@@ -22,7 +22,6 @@ def device_sync(device):
         print(f"device={device} is not yet suppported")
 
 
-torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
 torch._inductor.config.fx_graph_cache = True # Experimental feature to reduce compilation times, will be on by default in future
 
@@ -266,6 +265,10 @@ def main(
 ) -> None:
     """Generates text samples based on a pre-trained Transformer model and tokenizer.
     """
+    if "cpu" in device:
+        torch._inductor.config.coordinate_descent_tuning = False
+    else:
+        torch._inductor.config.coordinate_descent_tuning = True
     assert checkpoint_path.is_file(), checkpoint_path
 
     tokenizer_path = checkpoint_path.parent / "tokenizer.model"

--- a/mixtral-moe/generate.py
+++ b/mixtral-moe/generate.py
@@ -132,7 +132,7 @@ def encode_tokens(tokenizer, string, bos=True, device='cuda'):
     tokens = tokenizer.encode(string)
     if bos:
         tokens = [tokenizer.bos_id()] + tokens
-    return torch.tensor(tokens, dtype=torch.int, device=device)
+    return torch.tensor(tokens, dtype=torch.int, device=args.device)
 
 def _load_model(checkpoint_path, device, precision, use_tp):
     with torch.device('meta'):
@@ -248,7 +248,8 @@ def main(
         if (i != num_samples - 1 or not profile) or (use_tp and rank != 0):
             prof = contextlib.nullcontext()
         else:
-            torch.profiler._utils._init_for_cuda_graphs()
+            if device == 'cuda':
+                torch.profiler._utils._init_for_cuda_graphs()
             prof = torch.profiler.profile()
         with prof:
             y = generate(

--- a/mixtral-moe/generate.py
+++ b/mixtral-moe/generate.py
@@ -11,8 +11,8 @@ from typing import Optional, Tuple
 
 import torch
 import torch._dynamo.config
-from torch._inductor import config
-config.cpp.enable_kernel_profile = True
+import torch._inductor.config
+torch._inductor.config.cpp.enable_kernel_profile = True
 
 def device_sync(device):
     if "cuda" in device:
@@ -23,7 +23,6 @@ def device_sync(device):
         print(f"device={device} is not yet suppported")
 
 
-torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
 torch._inductor.config.fx_graph_cache = True # Experimental feature to reduce compilation times, will be on by default in future
 
@@ -173,6 +172,10 @@ def main(
 ) -> None:
     """Generates text samples based on a pre-trained Transformer model and tokenizer.
     """
+    if "cpu" in device:
+        torch._inductor.config.coordinate_descent_tuning = False
+    else:
+        torch._inductor.config.coordinate_descent_tuning = True
     assert checkpoint_path.is_file(), checkpoint_path
 
     tokenizer_path = checkpoint_path.parent / "tokenizer.model"

--- a/mixtral-moe/quantize.py
+++ b/mixtral-moe/quantize.py
@@ -129,11 +129,12 @@ class WeightOnlyBit8Linear(torch.nn.Module):
         self.register_buffer("scales", torch.ones(out_features, dtype=torch.bfloat16))
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return F.linear(input, self.weight.to(dtype=input.dtype)) * self.scales
         # TODO: This is a workaround to speedup int8 woq performance. Will remove this when
         # https://github.com/pytorch/pytorch/pull/120985 is in PyTorch stable release.
-        return linear_forward_int8(
-            input,
-            self.weight, self.scales, self.out_features)
+        #return linear_forward_int8(
+        #    input,
+        #    self.weight, self.scales, self.out_features)
 
 
 class ConditionalFeedForwardBit8(nn.Module):

--- a/mixtral-moe/quantize.py
+++ b/mixtral-moe/quantize.py
@@ -98,6 +98,20 @@ class WeightOnlyBit8QuantHandler:
         return self.mod
 
 
+# TODO: This is a workaround to speedup int8 woq performance. Will remove this when
+# https://github.com/pytorch/pytorch/pull/120985 is in PyTorch stable release.
+def linear_forward_int8(x, weight_int8pack, scales, out_features):
+    if x.is_cuda:
+        return F.linear(x, weight_int8pack.to(dtype=x.dtype)) * scales
+
+    origin_x_size = x.size()
+    x = x.reshape(-1, origin_x_size[-1])
+    c = torch.ops.aten._weight_int8pack_mm(x, weight_int8pack, scales)
+    new_shape = origin_x_size[:-1] + (out_features,)
+    c = c.reshape(new_shape)
+    return c
+
+
 class WeightOnlyBit8Linear(torch.nn.Module):
     __constants__ = ['in_features', 'out_features']
     in_features: int
@@ -115,7 +129,11 @@ class WeightOnlyBit8Linear(torch.nn.Module):
         self.register_buffer("scales", torch.ones(out_features, dtype=torch.bfloat16))
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        return F.linear(input, self.weight.to(dtype=input.dtype)) * self.scales
+        # TODO: This is a workaround to speedup int8 woq performance. Will remove this when
+        # https://github.com/pytorch/pytorch/pull/120985 is in PyTorch stable release.
+        return linear_forward_int8(
+            input,
+            self.weight, self.scales, self.out_features)
 
 
 class ConditionalFeedForwardBit8(nn.Module):

--- a/quantize.py
+++ b/quantize.py
@@ -366,11 +366,12 @@ class WeightOnlyInt8Linear(torch.nn.Module):
         self.register_buffer("scales", torch.ones(out_features, dtype=torch.bfloat16))
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return F.linear(input, self.weight.to(dtype=input.dtype)) * self.scales
         # TODO: This is a workaround to speedup int8 woq performance. Will remove this when
         # https://github.com/pytorch/pytorch/pull/120985 is in PyTorch stable release.
-        return linear_forward_int8(
-            input,
-            self.weight, self.scales, self.out_features)
+        #return linear_forward_int8(
+        #    input,
+        #    self.weight, self.scales, self.out_features)
 
 ##### weight only int4 per channel groupwise quantized code ######
 


### PR DESCRIPTION
This PR is to add CPU support in mixtral-moe for int8 woq. To improve int8 woq performance, we use `torch.ops.aten._weight_int8pack_mm` as an workaround. And it will be removed when https://github.com/pytorch/pytorch/pull/120985 is in PyTorch stable release.
Meanwhile, update int4 weight dimension, since https://github.com/pytorch/pytorch/pull/117475 has been merged into PyTorch.