### PR TITLE
Fix compile_prefill to prevent CUDA error

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -177,6 +177,7 @@ def generate(
     next_token = prefill(model, prompt.view(1, -1), input_pos, **sampling_kwargs)
     if is_speculative:
         prefill(draft_model, prompt.view(1, -1), input_pos, **sampling_kwargs)
+    next_token = next_token.clone()
     seq[T] = next_token
 
     input_pos = torch.tensor([T], device=device, dtype=torch.int)


### PR DESCRIPTION
When `--compile` and `--compile_prefill` are enabled simultaneously, an error occurs: `RuntimeError: CUDA error: device-side assert triggered`.
This issue was resolved by cloning a copy of `next_token` generated during the prefill phase.