### PR TITLE
Fixing quantize in int4 mode

### DIFF
--- a/quantize.py
+++ b/quantize.py
@@ -539,7 +539,7 @@ def quantize(
     device: str = default_device,
 ) -> None:
     assert checkpoint_path.is_file(), checkpoint_path
-    device = 'cpu'
+    print(f"Using device={device}")
     precision = torch.bfloat16
 
     print("Loading model ...")


### PR DESCRIPTION
Int4 quantization requires CUDA device, however, in current impl --device param was overridden with 'cpu' unconditionally.