### PR TITLE
Fix rope base issue with llama 3

### DIFF
--- a/model.py
+++ b/model.py
@@ -65,7 +65,7 @@ transformer_configs = {
     "Mistral-7B": dict(n_layer=32, n_head=32, n_local_heads=8, dim=4096, intermediate_size=14336, vocab_size=32000),
     "stories15M": dict(n_layer=6, n_head=6, dim=288),
     "stories110M": dict(n_layer=12, n_head=12, dim=768),
-    "Llama-3-8B": dict(block_size=8192, n_layer=32, n_head=32, n_local_heads=8, dim=4096, intermediate_size=14336, vocab_size=128256),
+    "Llama-3-8B": dict(block_size=8192, n_layer=32, n_head=32, n_local_heads=8, dim=4096, intermediate_size=14336, vocab_size=128256, rope_base=500000),
 }
 
 class KVCache(nn.Module):


### PR DESCRIPTION
Llama 3 has a non-standard rope base, but the huggingface config value is different from the name gpt-fast expects.  This causes issues, namely #179 .

From my testing, manually setting the rope base seems to fix the problem.