### PR TITLE
Decouple int4 weight with serialized format

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -77,7 +77,6 @@ def decode_n_tokens(model: Transformer, cur_token: torch.Tensor, input_pos: torc
             callback(new_tokens[-1])
             new_probs.append(next_prob.clone())
             cur_token = next_token.view(1, -1)
-
     return new_tokens, new_probs
 
 
@@ -241,6 +240,13 @@ def _load_model(checkpoint_path, device, precision, use_tp):
         apply_tp(model)
 
     model = model.to(device=device, dtype=precision)
+    if "int4" in str(checkpoint_path):
+        from quantize import WeightOnlyInt4Linear
+        for fqn, mod in model.named_modules():
+            if isinstance(mod, WeightOnlyInt4Linear):
+                weight = mod.weight.data
+                weight_int4pack = torch.ops.aten._convert_weight_to_int4pack(weight, mod.inner_k_tiles)
+                mod.weight = weight_int4pack
     return model.eval()
 
 def _get_model_size(model):


### PR DESCRIPTION
This PR is to decouple int4 weight with serialized format, so that int4 model checkpoint can be shared in different test machines or ISAs, without re-generating in one certain platform.

In int4 woq quantization, weight is saved as `[n][k / 2] uint8` (serialized format). The behavior of converting weight to int4 weight is moved to loading model in `generate.py`.

And this PR is based on https://github.com/pytorch/pytorch/pull/129940, which updates the input `weight` of `_convert_weight_to_int4pack` to `[n][k / 2] uint8`.