### PR TITLE
feat: add Llama-3.2-[1B/3B] support

### DIFF
--- a/model.py
+++ b/model.py
@@ -79,6 +79,12 @@ transformer_configs = {
     "llama-3.1-405b": dict(block_size=131072, n_layer=126, n_head=128, n_local_heads=8, dim=16384, intermediate_size=53248, vocab_size=128256, rope_base=500000,
         rope_scaling=dict(factor=8.0, low_freq_factor=1.0, high_freq_factor=4.0, original_max_position_embeddings=8192),
     ),
+    "llama-3.2-1b": dict(block_size=131072, n_layer=16, n_head=32, n_local_heads=8, dim=2048, intermediate_size=8192, vocab_size=128256, rope_base=500000,
+        rope_scaling=dict(factor=32.0, low_freq_factor=1.0, high_freq_factor=4.0, original_max_position_embeddings=8192),
+    ),
+    "llama-3.2-3b": dict(block_size=131072, n_layer=28, n_head=24, n_local_heads=8, dim=3072, intermediate_size=8192, vocab_size=128256, rope_base=500000,
+        rope_scaling=dict(factor=32.0, low_freq_factor=1.0, high_freq_factor=4.0, original_max_position_embeddings=8192),
+    ),
 }
 
 class KVCache(nn.Module):

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -7,7 +7,7 @@ import json
 import re
 import shutil
 import sys
-import os
+from typing import Dict
 from pathlib import Path
 from typing import Optional
 from safetensors.torch import load_file as load_safetensors_file
@@ -23,7 +23,9 @@ from model import ModelArgs
 @torch.inference_mode()
 def convert_hf_checkpoint(
     *,
-    checkpoint_dir: Path = Path("checkpoints/meta-Transformer/Transformer-2-7b-chat-hf"),
+    checkpoint_dir: Path = Path(
+        "checkpoints/meta-Transformer/Transformer-2-7b-chat-hf"
+    ),
     model_name: Optional[str] = None,
 ) -> None:
     if model_name is None:
@@ -32,8 +34,33 @@ def convert_hf_checkpoint(
     config = ModelArgs.from_name(model_name)
     print(f"Model config {config.__dict__}")
 
-    # Load the json file containing weight mapping
-    model_map_json_safetensors = checkpoint_dir / 'model.safetensors.index.json'
+    # Check for solo safetensors file
+    model_solo_safetensors = checkpoint_dir / "model.safetensors"
+    if model_solo_safetensors.is_file():
+        print(f"Found whole safetensors file at {model_solo_safetensors}")
+        state_dict = load_safetensors_file(str(model_solo_safetensors), device="cpu")
+    else:
+        # If solo file doesn't exist, merge indices
+        state_dict = merge_model_indices(checkpoint_dir)
+
+    final_result = process_state_dict(state_dict, config)
+
+    print(f"Saving checkpoint to {checkpoint_dir / 'model.pth'}")
+    torch.save(final_result, checkpoint_dir / "model.pth")
+
+    if "llama-3-" in model_name.lower() or "llama-3.1-" in model_name.lower():
+        if "llama-3.1-405b" in model_name.lower():
+            original_dir = checkpoint_dir / "original" / "mp16"
+        else:
+            original_dir = checkpoint_dir / "original"
+        tokenizer_model = original_dir / "tokenizer.model"
+        tokenizer_model_tiktoken = checkpoint_dir / "tokenizer.model"
+        print(f"Copying {tokenizer_model} to {tokenizer_model_tiktoken}")
+        shutil.copy(tokenizer_model, tokenizer_model_tiktoken)
+
+
+def merge_model_indices(checkpoint_dir: Path) -> Dict[str, torch.Tensor]:
+    model_map_json_safetensors = checkpoint_dir / "model.safetensors.index.json"
     model_map_json_pytorch = checkpoint_dir / "pytorch_model.bin.index.json"
     model_map_json = None
 
@@ -51,58 +78,37 @@ def convert_hf_checkpoint(
             except AssertionError:
                 print(f"{model_map_json_pytorch} not found")
 
-    # If the solo safetensors file exists, we should load it directly
-    model_solo_safetensors = checkpoint_dir / 'model.safetensors'
-    if model_solo_safetensors.is_file():
-        print(f"Found whole safetensors file at {model_solo_safetensors}")
-        merged_result = load_safetensors_file(str(model_solo_safetensors), device="cpu")
-    else:
-        if model_map_json is None:
-            raise Exception("No model map found!")
+    if model_map_json is None:
+        raise Exception("No model map found!")
 
-        with open(model_map_json) as json_map:
-            bin_index = json.load(json_map)
+    with open(model_map_json) as json_map:
+        bin_index = json.load(json_map)
 
-        # Refactored merging logic into a separate function
-        merged_result = merge_weights(checkpoint_dir, bin_index)
-
-    # Refactored key mapping logic into a separate function
-    final_result = map_keys(merged_result, config)
-
-    print(f"Saving checkpoint to {checkpoint_dir / 'model.pth'}")
-    torch.save(final_result, checkpoint_dir / "model.pth")
-
-    if 'llama-3-' in model_name.lower() or 'llama-3.1-' or 'llama-3.2-' in model_name.lower():
-        if 'llama-3.1-405b' in model_name.lower():
-            original_dir = checkpoint_dir / "original" / "mp16"
-        else:
-            original_dir = checkpoint_dir / "original"
-        tokenizer_model = original_dir / "tokenizer.model"
-        tokenizer_model_tiktoken = checkpoint_dir / "tokenizer.model"
-        print(f"Copying {tokenizer_model} to {tokenizer_model_tiktoken}")
-        shutil.copy(tokenizer_model, tokenizer_model_tiktoken)
-
-def merge_weights(checkpoint_dir, bin_index):
     bin_files = {checkpoint_dir / bin for bin in bin_index["weight_map"].values()}
+
     merged_result = {}
     for file in sorted(bin_files):
         if "safetensors" in str(file):
             state_dict = load_safetensors_file(str(file), device="cpu")
-            merged_result.update(state_dict)
         else:
-            state_dict = torch.load(str(file), map_location="cpu", mmap=True, weights_only=True)
-            merged_result.update(state_dict)
+            state_dict = torch.load(
+                str(file), map_location="cpu", mmap=True, weights_only=True
+            )
+        merged_result.update(state_dict)
     return merged_result
 
-def map_keys(merged_result, config):
+
+def process_state_dict(
+    state_dict: Dict[str, torch.Tensor], config: ModelArgs
+) -> Dict[str, torch.Tensor]:
     weight_map = {
         "model.embed_tokens.weight": "tok_embeddings.weight",
         "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.wq.weight",
         "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.wk.weight",
         "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.wv.weight",
         "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
-        'model.layers.{}.self_attn.rotary_emb.inv_freq': None,
-        'model.layers.{}.mlp.gate_proj.weight': 'layers.{}.feed_forward.w1.weight',
+        "model.layers.{}.self_attn.rotary_emb.inv_freq": None,
+        "model.layers.{}.mlp.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
         "model.layers.{}.mlp.up_proj.weight": "layers.{}.feed_forward.w3.weight",
         "model.layers.{}.mlp.down_proj.weight": "layers.{}.feed_forward.w2.weight",
         "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
@@ -112,10 +118,10 @@ def map_keys(merged_result, config):
     }
 
     final_result = {}
-    for key, value in merged_result.items():
+    for key, value in state_dict.items():
         if "layers" in key:
-            abstract_key = re.sub(r'(\d+)', '{}', key)
-            layer_num = re.search(r'\d+', key).group(0)
+            abstract_key = re.sub(r"(\d+)", "{}", key)
+            layer_num = re.search(r"\d+", key).group(0)
             new_key = weight_map.get(abstract_key)
             if new_key is None:
                 continue
@@ -123,36 +129,48 @@ def map_keys(merged_result, config):
         else:
             new_key = weight_map.get(key)
 
-        if new_key is not None:
+        if new_key:
             final_result[new_key] = value
+
+    # tie embeddings if the output weight does not exist
+    # necessary for 1B and 3B models
+    if "output.weight" not in final_result:
+        print("Tying embeddings - this is only necessary for 1B and 3B models")
+        final_result["output.weight"] = final_result["tok_embeddings.weight"]
+
+    def permute(w, n_head):
+        dim = config.dim
+        return (
+            w.view(n_head, 2, config.head_dim // 2, dim)
+            .transpose(1, 2)
+            .reshape(config.head_dim * n_head, dim)
+        )
 
     for key in tuple(final_result.keys()):
         if "wq" in key:
             q = final_result[key]
             k = final_result[key.replace("wq", "wk")]
             v = final_result[key.replace("wq", "wv")]
-            q = permute(q, config.n_head, config)
-            k = permute(k, config.n_local_heads, config)
+            q = permute(q, config.n_head)
+            k = permute(k, config.n_local_heads)
             final_result[key.replace("wq", "wqkv")] = torch.cat([q, k, v])
             del final_result[key]
             del final_result[key.replace("wq", "wk")]
             del final_result[key.replace("wq", "wv")]
+
     return final_result
 
-def permute(w, n_head, config):
-    dim = config.dim
-    return (
-        w.view(n_head, 2, config.head_dim // 2, dim)
-        .transpose(1, 2)
-        .reshape(config.head_dim * n_head, dim)
-    )
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(description='Convert HuggingFace checkpoint.')
-    parser.add_argument('--checkpoint_dir', type=Path, default=Path("checkpoints/meta-llama/llama-2-7b-chat-hf"))
-    parser.add_argument('--model_name', type=str, default=None)
+
+    parser = argparse.ArgumentParser(description="Convert HuggingFace checkpoint.")
+    parser.add_argument(
+        "--checkpoint_dir",
+        type=Path,
+        default=Path("checkpoints/meta-llama/llama-2-7b-chat-hf"),
+    )
+    parser.add_argument("--model_name", type=str, default=None)
 
     args = parser.parse_args()
     convert_hf_checkpoint(


### PR DESCRIPTION
This PR adds support for the small models in the Llama 3.2 release - 1B and 3B. 

There are two pieces of custom logic we needed to implement for this to work:

1. Support safetensors files without merging. Larger models require multiple safetensors files to fit, but the 1B model fits into a single exported file. As a result, we refactor the HF conversion script logic, and skip the state dict merging if we can find a single file with all the weights.
2. Support tied embedding weights. The smaller models share input/output embeddings, presumably to save parameters, but the larger models don't. In the conversion step, we check if the output weights are empty and if so copy the input embeddings over.  

I think this is all we need - the local testing generates reasonable results for 1B, 3B, and 8B. note: in local testing I needed to comment out `torch._functorch.config.enable_autograd_cache = True` with `torch 2.4.1` - I assume this was merged and supported by default?

Testing: 
3B model:
```
export MODEL_REPO=meta-llama/Llama-3.2-3B-Instruct; uv run generate.py --max_new_tokens 16 --checkpoint_path "checkpoints/${MODEL_REPO}/model.pth"
 --prompt "Hello, my name is"
Using device=cuda
Loading model ...
Time to load model: 5.05 seconds
/home/hua/.cache/hermit/pkg/python3@3.10/install/lib/python3.10/contextlib.py:103: FutureWarning: `torch.backends.cuda.sdp_kernel()` is deprecated. In the future, this context manager will be removed. Please see `torch.nn.attention.sdpa_kernel()` for the new context manager, with updated signature.
  self.gen = func(*args, **kwds)
<|begin_of_text|>Hello, my name is [Your Name] and I am a [Your Position/Affiliation] at
Time for inference 1: 0.61 sec total, 26.22 tokens/sec
Bandwidth achieved: 168.46 GB/s
FLOPS achieved: 0.23 TF/s

<|begin_of_text|>Hello, my name is [Name] and I'm interested in learning more about [Topic]. I'm
Time for inference 2: 0.40 sec total, 39.69 tokens/sec
Bandwidth achieved: 255.02 GB/s
FLOPS achieved: 0.35 TF/s

<|begin_of_text|>Hello, my name is Ryan and I am a freshman in high school. I am excited to participate in
Time for inference 3: 0.36 sec total, 44.49 tokens/sec
Bandwidth achieved: 285.87 GB/s
FLOPS achieved: 0.39 TF/s

<|begin_of_text|>Hello, my name is Ryan and I am a teacher at Parkside Secondary School.

I have been teaching
Time for inference 4: 0.36 sec total, 44.30 tokens/sec
Bandwidth achieved: 284.67 GB/s
FLOPS achieved: 0.39 TF/s

<|begin_of_text|>Hello, my name is Emily, and I am an entrepreneur who has been creating and selling handmade jewelry online
Time for inference 5: 0.35 sec total, 45.38 tokens/sec
Bandwidth achieved: 291.57 GB/s
FLOPS achieved: 0.40 TF/s

==========
Batch Size: 1
Prompt Length: 6
Generated tokens: 16
Average tokens/sec: 40.02
Memory used: 7.42 GB
```
1B model:
```
export MODEL_REPO=meta-llama/Llama-3.2-1B-Instruct; uv run generate.py --max_new_tokens 16 --checkpoint_path "checkpoints/${MODEL_REPO}/model.pth" --prompt "Hello, my name is"
Using device=cuda
Loading model ...
Time to load model: 0.71 seconds
/home/hua/.cache/hermit/pkg/python3@3.10/install/lib/python3.10/contextlib.py:103: FutureWarning: `torch.backends.cuda.sdp_kernel()` is deprecated. In the future, this context manager will be removed. Please see `torch.nn.attention.sdpa_kernel()` for the new context manager, with updated signature.
  self.gen = func(*args, **kwds)
<|begin_of_text|>Hello, my name is Emily and I’m the owner of a small bakery in the town of Willow Creek
Time for inference 1: 0.44 sec total, 36.52 tokens/sec
Bandwidth achieved: 90.26 GB/s
FLOPS achieved: 0.12 TF/s                                                                                                                                                                                                                                                                                                                                           <|begin_of_text|>Hello, my name is [Name] and I'm the new face of your company's marketing efforts.
Time for inference 2: 0.19 sec total, 84.40 tokens/sec
Bandwidth achieved: 208.62 GB/s
FLOPS achieved: 0.29 TF/s

<|begin_of_text|>Hello, my name is Bertha and I'm a librarian. I've been a part of this wonderful
Time for inference 3: 0.25 sec total, 64.19 tokens/sec
Bandwidth achieved: 158.66 GB/s
FLOPS achieved: 0.22 TF/s

<|begin_of_text|>Hello, my name is Sona, and I'm the owner of "Eternal Bliss Spa" on
Time for inference 4: 0.24 sec total, 66.58 tokens/sec
Bandwidth achieved: 164.57 GB/s
FLOPS achieved: 0.23 TF/s

<|begin_of_text|>Hello, my name is Emily, and I'm an aspiring filmmaker. I've been working on a project
Time for inference 5: 0.25 sec total, 64.00 tokens/sec
Bandwidth achieved: 158.20 GB/s
FLOPS achieved: 0.22 TF/s

==========
Batch Size: 1
Prompt Length: 6
Generated tokens: 16
Average tokens/sec: 63.14
Memory used: 3.12 GB
```
8B model (regression check)
```
export MODEL_REPO=meta-llama/Meta-Llama-3-8B-Instruct; uv run generate.py --max_new_tokens 16 --checkpoint_path "checkpoints/${MODEL_REPO}/model.pth" --prompt "Hello, my name is"
Using device=cuda
Loading model ...
Time to load model: 2.55 seconds
/home/hua/.cache/hermit/pkg/python3@3.10/install/lib/python3.10/contextlib.py:103: FutureWarning: `torch.backends.cuda.sdp_kernel()` is deprecated. In the future, this context manager will be removed. Please see `torch.nn.attention.sdpa_kernel()` for the new context manager, with updated signature.
  self.gen = func(*args, **kwds)
<|begin_of_text|>Hello, my name is Victoria and I’m a therapist. I work with individuals, couples, and families
Time for inference 1: 0.66 sec total, 24.26 tokens/sec
Bandwidth achieved: 364.14 GB/s
FLOPS achieved: 0.50 TF/s                                                                                                                                                                                                                                                                                                                                           <|begin_of_text|>Hello, my name is [Name] and I'm here to help you with your request. Can you
Time for inference 2: 1.23 sec total, 12.97 tokens/sec
Bandwidth achieved: 194.62 GB/s
FLOPS achieved: 0.27 TF/s

<|begin_of_text|>Hello, my name is Ryan and I am a 3rd generation, small business owner in the golf
Time for inference 3: 0.82 sec total, 19.58 tokens/sec
Bandwidth achieved: 293.88 GB/s
FLOPS achieved: 0.40 TF/s

<|begin_of_text|>Hello, my name is Srijith and I'm a software engineer with 3+ years of experience
Time for inference 4: 0.59 sec total, 27.14 tokens/sec
Bandwidth achieved: 407.37 GB/s
FLOPS achieved: 0.56 TF/s

<|begin_of_text|>Hello, my name is Emily and I am thrilled to be working with the talented and dedicated team at B
Time for inference 5: 0.56 sec total, 28.36 tokens/sec
Bandwidth achieved: 425.64 GB/s
FLOPS achieved: 0.59 TF/s

==========
Batch Size: 1
Prompt Length: 6
Generated tokens: 16
Average tokens/sec: 22.46
Memory used: 16.09 GB
```